### PR TITLE
fix(rules): Disable no-param-reassign, class-methods-use-this and no-…

### DIFF
--- a/.changeset/fifty-lamps-cross.md
+++ b/.changeset/fifty-lamps-cross.md
@@ -1,0 +1,5 @@
+---
+"@octetstream/eslint-config": patch
+---
+
+Disable no-param-reassign, class-methods-use-this and no-void rules

--- a/readme.md
+++ b/readme.md
@@ -385,3 +385,15 @@ import {something} from "./path/to/a/module"
 #### [`import/prefer-default-export`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/prefer-default-export.md)
 
 The use of default and named exports are not restricted.
+
+#### [`no-param-reassign`](https://eslint.org/docs/rules/no-param-reassign)
+
+Allow function params reassign.
+
+#### [`class-methods-use-this`](https://eslint.org/docs/rules/class-methods-use-this)
+
+Allow methods without use of `this`, because there are many cases when you don't need `this` inside of class instance methods.
+
+#### [`no-void`](https://eslint.org/docs/rules/no-void)
+
+Allow use of [`void`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/void) operator.

--- a/src/rules/base.ts
+++ b/src/rules/base.ts
@@ -61,5 +61,14 @@ export default {
   "no-await-in-loop": "off",
 
   // Override this rules to allow `for...of` loops, because they're native and prohibit `WithStatement`
-  "no-restricted-syntax": ["error", "WithStatement"]
+  "no-restricted-syntax": ["error", "WithStatement"],
+
+  // Allow param reassign, sometimes it can be useful
+  "no-param-reassign": "off",
+
+  // Allow class methods w/o use of `this`
+  "class-methods-use-this": "off",
+
+  // Allow use of the `void` operator
+  "no-void": "off"
 } satisfies Partial<ESLintRules>


### PR DESCRIPTION
### Details

This PR disables few unnecessary rules.

### Notable changes

- [x] Disable no-param-reassign, class-methods-use-this and no-void rules;

### Checklist

- [x] I have self-reviewed my changes before asking for a review from maintainers
- [x] I have added changesets <!-- optional -->
- [x] ~~I have brought tests <!-- if necessary -->~~
